### PR TITLE
Add input of the workflow as part of the context.

### DIFF
--- a/garcon/event.py
+++ b/garcon/event.py
@@ -64,12 +64,16 @@ def get_current_context(events):
     for event in events:
         event_id = event.get('eventId')
         event_type = event.get('eventType')
+        result = None
 
-        if event_type != 'ActivityTaskCompleted':
-            continue
+        if event_type == 'ActivityTaskCompleted':
+            attributes = event['activityTaskCompletedEventAttributes']
+            result = attributes.get('result')
 
-        attributes = event['activityTaskCompletedEventAttributes']
-        result = attributes.get('result')
+        if event_type == 'WorkflowExecutionStarted':
+            attributes = event['workflowExecutionStartedEventAttributes']
+            result = attributes.get('input')
+
         if result:
             context.update(json.loads(result))
 


### PR DESCRIPTION
Some workflows can be generic enough to work with a set of parameters that can be provided
at the execution of the workflow.