### PR TITLE
Add timeout on methods.

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -72,6 +72,19 @@ class Activity(swf.ActivityWorker):
         self.task_list = self.task_list or data.get('task_list')
         self.tasks = getattr(self, 'tasks', []) or data.get('tasks')
 
+    @property
+    def timeout(self):
+        """Return the timeout in seconds.
+
+        This timeout corresponds on when the activity has started and when we
+        assume the activity has ended (which corresponds in boto to
+        start_to_close_timeout.)
+
+        Return:
+            int: Task list timeout.
+        """
+
+        return self.task_list.timeout
 
 
 class ActivityWorker():

--- a/garcon/decider.py
+++ b/garcon/decider.py
@@ -140,7 +140,8 @@ class DeciderWorker(swf.Decider):
                 current.name,
                 self.version,
                 task_list=current.task_list,
-                input=json.dumps(context))
+                input=json.dumps(context),
+                start_to_close_timeout=current.timeout)
         else:
             activities = list(
                 activity.find_uncomplete_activities(

--- a/garcon/task.py
+++ b/garcon/task.py
@@ -20,10 +20,39 @@ from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 
 
+DEFAULT_TASK_TIMEOUT = 600  # 10 minutes.
+
+
 class Tasks():
 
     def __init__(self, *args):
         self.tasks = args
+
+    @property
+    def timeout(self):
+        """Calculate and return the timeout for an activity.
+
+        The calculation of the timeout is pessimistic: it takes the worse case
+        scenario (even for asynchronous task lists, it supposes there is only
+        one thread completed at a time.)
+
+        Return:
+            int: The timeout.
+        """
+
+        timeout = 0
+
+        for task in self.tasks:
+            task_timeout = DEFAULT_TASK_TIMEOUT
+            task_details = getattr(task, '__garcon__', None)
+
+            if task_details:
+                task_timeout = task_details.get(
+                    'timeout', DEFAULT_TASK_TIMEOUT)
+
+            timeout = timeout + task_timeout
+
+        return timeout
 
 
 class SyncTasks(Tasks):
@@ -44,7 +73,7 @@ class AsyncTasks(Tasks):
 
     def execute(self, context):
         result = dict()
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             tasks = []
             for task in self.tasks:
                 tasks.append(executor.submit(task, context))
@@ -53,3 +82,35 @@ class AsyncTasks(Tasks):
                 data = future.result()
                 result.update(data or {})
         return result
+
+
+def timeout(time):
+    """Wrapper for a task to define its timeout.
+
+    Args:
+        time (int): the timeout in seconds
+    """
+
+    def wrapper(fn):
+        decorate(fn, 'timeout', time)
+        return fn
+
+    return wrapper
+
+
+def decorate(fn, key=None, value=None):
+    """Add the garcon property to the function.
+
+    Args:
+        fn (callable): The function to alter.
+        key (string): The key to set (optional.)
+        value (any): The value to set (optional.)
+    """
+
+    if not hasattr(fn, '__garcon__'):
+        setattr(fn, '__garcon__', dict())
+
+    if key:
+        fn.__garcon__.update({
+            key: value
+        })

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -43,3 +43,71 @@ def test_aynchronous_tasks():
         assert current_task.called
 
     assert resp == expected_response
+
+
+def test_timeout_decorator():
+    """Test the timeout decorator.
+    """
+
+    timeout = 10
+    @task.timeout(timeout)
+    def test():
+        pass
+
+    assert test.__garcon__.get('timeout') == timeout
+
+
+def test_decorator():
+    """Test the Decorator.
+
+    It should add __garcon__ to the method and if a key / value is
+    passed, it should add it.
+    """
+
+    def test():
+        pass
+
+    task.decorate(test)
+    assert hasattr(test, '__garcon__')
+
+    task.decorate(test, 'foo')
+    assert test.__garcon__.get('foo') is None
+
+    task.decorate(test, 'foo', 'bar')
+    assert test.__garcon__.get('foo') is 'bar'
+
+
+def test_calculate_timeout_with_no_tasks():
+    """Task list without task has no timeout.
+    """
+
+    task_list = task.Tasks()
+    assert not task_list.timeout
+
+
+def test_calculate_default_timeout():
+    """Tasks that do not have a set timeout get the default timeout.
+    """
+
+    task_list = task.Tasks(lambda x: x)
+    assert task_list.timeout == task.DEFAULT_TASK_TIMEOUT
+
+
+def test_calculate_timeout():
+    """Check methods that have set timeout.
+    """
+
+    timeout = 10
+
+    @task.timeout(timeout)
+    def task_a():
+        pass
+
+    task_list = task.Tasks(task_a)
+    assert task_list.timeout == timeout
+
+    def task_b():
+        pass
+
+    task_list = task.Tasks(task_a, task_b)
+    assert task_list.timeout == timeout + task.DEFAULT_TASK_TIMEOUT


### PR DESCRIPTION
Some tasks may require more time than the default timeout. This update allows to set a timeout
on specific tasks.

Example:

    from garcon import task

    @task.timeout(3600)
    def task_a(context):
        pass