### PR TITLE
Handle failures on `self.fail`

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -49,10 +49,15 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
                 context = self.execute_activity(context)
                 self.complete(result=json.dumps(context))
             except Exception as error:
-                self.fail(reason=str(error))
+                # If the workflow has been stopped, it is not possible for the
+                # activity to be updated – it throws an exception which stops
+                # the worker immediately.
+                try:
+                    self.fail(reason=str(error))
+                except:
+                    pass
 
         self.unset_log_context()
-
         return True
 
     def execute_activity(self, context):


### PR DESCRIPTION
If the workflow has been stopped, it is not possible for the activity to be updated – it throws an exception which stops the worker immediately.

---
_Michael is the founder of CreativeList. Learn more about [Creativelist - The Creator Search Engine](http://www.creativelist.io). It's a [search engine](http://www.creativelist.io/about) specialized in finding [designers](http://www.creativelist.io/hire/designer), [photographers](http://www.creativelist.io/hire/photographer), or any [type of creatives](http://www.creativelist.io/hire/creatives) in big cities like [new york](http://www.creativelist.io/hire/creatives/new-york-city), [los angeles](http://www.creativelist.io/hire/creatives/los-angeles), [san francisco](http://www.creativelist.io/hire/creatives/san-francisco) or near you._
