### PR TITLE
Add decorators.

### DIFF
--- a/garcon/task.py
+++ b/garcon/task.py
@@ -17,6 +17,7 @@ Note:
     the way you want.
 """
 
+import copy
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
 
@@ -87,6 +88,29 @@ class AsyncTasks(Tasks):
         return result
 
 
+def decorate(timeout=None, enable_contextify=True):
+    """Generic task decorator for tasks.
+
+    Args:
+        timeout (int): The timeout of the task (see timeout).
+        contextify (boolean): If the task can be contextified (see contextify).
+
+    Return:
+        callable: The wrapper.
+    """
+
+    def wrapper(fn):
+        if timeout:
+            _decorate(fn, 'timeout', timeout)
+
+        if enable_contextify:
+            contextify(fn)
+
+        return fn
+
+    return wrapper
+
+
 def timeout(time):
     """Wrapper for a task to define its timeout.
 
@@ -95,13 +119,13 @@ def timeout(time):
     """
 
     def wrapper(fn):
-        decorate(fn, 'timeout', time)
+        _decorate(fn, 'timeout', time)
         return fn
 
     return wrapper
 
 
-def decorate(fn, key=None, value=None):
+def _decorate(fn, key=None, value=None):
     """Add the garcon property to the function.
 
     Args:
@@ -117,3 +141,107 @@ def decorate(fn, key=None, value=None):
         fn.__garcon__.update({
             key: value
         })
+
+
+def contextify(fn):
+    """Decorator to take values from the context and apply them to fn.
+
+    The goal of this decorator is to allow methods to be called with different
+    values from the same context. For instance: if you need to increase the
+    throughtput of two different dynamodb tables, you will need to pass a
+    table name, table index, and the new throughtput.
+
+    If you have more than one table, it gets difficult to manage. With this
+    decorator, it's a little easier::
+
+        @contextify
+        def increase_dynamodb_throughtput(
+                activity, context, table_name=None, table_index=None,
+                table_throughtput=None):
+            print(table_name)
+        activity_task = increase_dynamodb_throughtput.fill(
+            table_name='dynamodb.table_name1',
+            table_index='dynamodb.table_index1',
+            table_throughtput='dynamodb.table_throughtput1')
+        context = dict(
+            'dynamodb.table_name1': 'table_name',
+            'dynamodb.table_index1': 'index',
+            'dynamodb.table_throughtput1': 'throughtput1')
+        activity_task(..., context) # shows table_name
+    """
+
+    def fill(namespace=None, **requirements):
+
+        def wrapper(activity, context, **kwargs):
+            kwargs.update(
+                fill_function_call(fn, requirements, activity, context))
+
+            response = fn(**kwargs)
+            if not response or not namespace:
+                return response
+
+            return namespace_result(response, namespace)
+        return wrapper
+
+    fn.fill = fill
+    return fn
+
+
+def fill_function_call(fn, requirements, activity, context):
+    """Fill a function calls from values from the context to the variable.
+
+    Args:
+        fn (callable): the function to call.
+        requirements (dict): the requirements. The key represent the variable
+            name and the value represents where the value is in the context.
+        activity (ActivityWorker): the current activity worker.
+        context (dict): the current context.
+
+    Return:
+        dict: The arguments to call the method with.
+    """
+
+    function_arguments = fn.__code__.co_varnames[:fn.__code__.co_argcount]
+    kwargs = dict()
+
+    for argument in function_arguments:
+        value = copy.deepcopy(context.get(requirements.get(argument)))
+
+        if argument == 'context':
+            raise Exception(
+                'Data used from the context should be explicit. A task should'
+                ' not randomly access information from the context.')
+
+        elif argument == 'activity':
+            value = activity
+
+        kwargs.update({
+            argument: value
+        })
+
+    return kwargs
+
+
+def namespace_result(dictionary, namespace):
+    """Namespace the response
+
+    This method takes the keys in the map and add a prefix to all the keys
+    (the namespace)::
+
+        resp = dict(key='value', index='storage')
+        namespace_response(resp, 'namespace')
+        # Returns: {'namespace.index': 'storage', 'namespace.key': 'value'}
+
+    Args:
+        dictionary (dict): The dictionary to update.
+        map (dict): The keys to update.
+
+    Return:
+        Dict: the updated dictionary
+    """
+
+    if not namespace:
+        return dictionary
+
+    return {
+        (namespace + '.' + key): value for key, value in dictionary.items()}

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -4,6 +4,8 @@ try:
 except:
     from mock import MagicMock
 
+import pytest
+
 from garcon import task
 
 
@@ -71,14 +73,68 @@ def test_decorator():
     def test():
         pass
 
-    task.decorate(test)
+    task._decorate(test)
     assert hasattr(test, '__garcon__')
 
-    task.decorate(test, 'foo')
+    task._decorate(test, 'foo')
     assert test.__garcon__.get('foo') is None
 
-    task.decorate(test, 'foo', 'bar')
+    task._decorate(test, 'foo', 'bar')
     assert test.__garcon__.get('foo') is 'bar'
+
+
+def test_task_decorator():
+    """Test the task decorator.
+    """
+
+    timeout = 40
+    userinfo = 'something'
+
+    @task.decorate(timeout=timeout)
+    def test(user):
+        assert user is userinfo
+
+    assert test.__garcon__.get('timeout') == timeout
+    assert callable(test.fill)
+
+    call = test.fill(user='user')
+    call(None, dict(user='something'))
+
+
+def test_task_decorator_with_activity():
+    """Test the task decorator with an activity.
+    """
+
+    current_activity = MagicMock()
+
+    @task.decorate()
+    def test(activity):
+        activity()
+        assert activity is current_activity
+
+    call = test.fill()
+    call(current_activity, dict())
+
+    assert current_activity.called
+
+
+def test_task_decorator_with_context():
+    """Test the task decorator with an activity.
+    """
+
+    current_context = {}
+    spy = MagicMock()
+
+    @task.decorate()
+    def test(context):
+        spy()
+
+    call = test.fill()
+
+    with pytest.raises(Exception):
+        call(None, current_context)
+
+    assert not spy.called
 
 
 def test_calculate_timeout_with_no_tasks():
@@ -115,3 +171,129 @@ def test_calculate_timeout():
 
     task_list = task.Tasks(task_a, task_b)
     assert task_list.timeout == str(timeout + task.DEFAULT_TASK_TIMEOUT)
+
+
+
+def test_contextify_added_fill():
+    """Verify that calling contextify on a method added .fill on the method.
+    """
+
+    @task.contextify
+    def test(activity, context, something):
+        pass
+
+    assert test
+    assert test.fill
+
+
+def test_contextify_default_method_call():
+    """Test that the contextify decorator is not altering the method itself.
+    The contextify decorator should preserve the format of the method, it
+    allows us to use it in more than one context.
+    """
+
+    response = dict(somekey='somevalue')
+    spy = MagicMock()
+
+    @task.contextify
+    def method(activity, key_to_replace, key_to_not_replace=None):
+        assert key_to_replace == 'value'
+        assert key_to_not_replace is None
+        spy()
+        return response
+
+    assert method(None, 'value') is response
+    assert spy.called
+
+
+def test_contextify():
+    """Try using contextify on a method.
+    """
+
+    value = 'random'
+    kwargs_value = 'more-random'
+    return_value = 'a value'
+    spy = MagicMock()
+
+    @task.contextify
+    def method(
+        activity, key_to_replace, key_not_to_replace=None,
+            kwargs_to_replace=None):
+
+        assert not key_not_to_replace
+        assert key_to_replace == value
+        assert kwargs_to_replace == kwargs_value
+        spy()
+        return dict(return_value=return_value)
+
+    fn = method.fill(
+        key_to_replace='context.key',
+        kwargs_to_replace='context.kwarg_key')
+
+    resp = fn(None, {'context.key': value, 'context.kwarg_key': kwargs_value})
+
+    assert isinstance(resp, dict)
+    assert resp.get('return_value') is return_value
+
+
+def test_contextify_with_mapped_response():
+    """Test the contextify method with mapped response.
+    """
+
+    return_value = 'a value'
+
+    @task.contextify
+    def method(
+        activity, key_to_replace, key_not_to_replace=None,
+            kwargs_to_replace=None):
+
+        return dict(return_value=return_value)
+
+    fn = method.fill(
+        key_to_replace='context.key',
+        kwargs_to_replace='context.kwarg_key',
+        namespace='somethingrandom')
+
+    resp = fn(None, {'context.key': 'test', 'context.kwarg_key': 'a'})
+
+    assert isinstance(resp, dict)
+    assert len(resp) == 1
+    assert resp.get('somethingrandom.return_value') is return_value
+
+
+def test_fill_function_call():
+    """Test filling the function call.
+    """
+
+    def test_function(activity, arg_one, key, kwarg_one=None, kwarg_two=None):
+        pass
+
+    requirements = dict(arg_one='context.arg', kwarg_one='context.kwarg')
+    activity = None
+    context = {
+        'context.arg': 'arg.value',
+        'context.kwarg': 'kwarg.value'}
+
+    data = task.fill_function_call(
+        test_function, requirements, activity, context)
+
+    assert not data.get('activity')
+    assert not data.get('context')
+    assert not data.get('key')
+    assert not data.get('kwarg_two')
+    assert data.get('arg_one') == 'arg.value'
+    assert data.get('kwarg_one') == 'kwarg.value'
+    test_function(**data)
+
+
+def test_namespace_result():
+    """Test namespacing the results.
+    """
+
+    value = 'foo'
+
+    resp = task.namespace_result(dict(test=value), '')
+    assert resp.get('test') == value
+
+    resp = task.namespace_result(dict(test=value), 'namespace')
+    assert resp.get('namespace.test') == value


### PR DESCRIPTION
Two new decorators have been added:
* `task.decorator`: which is a generic decorator for tasks. You can pass a timeout and
  `enable_contextify`.
* `task.contextify`: which methods gets information from the context and send it to the
   task.

Background:

The context is being passed to all tasks. Having the ability to know which task consume
what information makes it easier to see additional dependencies between tasks. For
instance:

```
activity = create(
    name=activity_name,
    tasks=SyncTasks(
        send_email.fill(
            user_email='context.user_email',
            user_full_name='context.user.full_name')))
```

To get the `fill` method, you can either do:

```
from garcon import tasks

@tasks.contextify
def send_email(user_email):
    pass

@tasks.decorate()
def send_email(user_email):
    pass
```

Please note:

> 1. Using the decorate method does not allow you to use `context` anymore. The goal is
> to make sure that all values needed from the context are passed to the task (making
> it explicit what the task need.)
>
> 2. Activity is now an optional param. If you don't need it, don't add it into the
> signature of the method.