### PR TITLE
Add the runner param.

### DIFF
--- a/garcon/runner.py
+++ b/garcon/runner.py
@@ -15,16 +15,15 @@ DEFAULT_TASK_TIMEOUT = 600  # 10 minutes.
 
 class BaseRunner():
 
-    def __init__(self, *args):
-        self.tasks = args
-
-    @property
-    def timeout(self):
+    def estimate_timeout(self, tasks):
         """Calculate and return the timeout for an activity.
 
         The calculation of the timeout is pessimistic: it takes the worse case
         scenario (even for asynchronous task lists, it supposes there is only
         one thread completed at a time.)
+
+        Args:
+            tasks (list): the list of tasks the runner needs to execute.
 
         Return:
             str: The timeout (boto requires the timeout to be a string and not
@@ -33,7 +32,7 @@ class BaseRunner():
 
         timeout = 0
 
-        for task in self.tasks:
+        for task in tasks:
             task_timeout = DEFAULT_TASK_TIMEOUT
             task_details = getattr(task, '__garcon__', None)
 
@@ -45,7 +44,7 @@ class BaseRunner():
 
         return str(timeout)
 
-    def execute(self, activity, context):
+    def execute(self, activity, tasks, context):
         """Execution of the tasks.
         """
 
@@ -54,9 +53,9 @@ class BaseRunner():
 
 class Sync(BaseRunner):
 
-    def execute(self, activity, context):
+    def execute(self, activity, tasks, context):
         result = dict()
-        for task in self.tasks:
+        for task in tasks:
             task_context = dict(list(result.items()) + list(context.items()))
             resp = task(task_context, activity=activity)
             result.update(resp or dict())
@@ -65,18 +64,18 @@ class Sync(BaseRunner):
 
 class Async(BaseRunner):
 
-    def __init__(self, *args, **kwargs):
-        self.tasks = args
-        self.max_workers = kwargs.get('max_workers', 3)
+    def __init__(self, max_workers=3):
+        self.max_workers = max_workers
 
-    def execute(self, activity, context):
+    def execute(self, activity, tasks, context):
         result = dict()
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            tasks = []
-            for task in self.tasks:
-                tasks.append(executor.submit(task, context, activity=activity))
+            task_threads = []
+            for task in tasks:
+                task_threads.append(
+                    executor.submit(task, context, activity=activity))
 
-            for future in futures.as_completed(tasks):
+            for future in futures.as_completed(task_threads):
                 data = future.result()
                 result.update(data or {})
         return result

--- a/tests/fixtures/flows/example.py
+++ b/tests/fixtures/flows/example.py
@@ -11,29 +11,33 @@ create = activity.create(domain)
 
 activity_1 = create(
     name='activity_1',
-    tasks=runner.Sync(
+    runner=runner.Sync(),
+    tasks=[
         lambda activity, context:
-            print('activity_1')))
+            print('activity_1')])
 
 activity_2 = create(
     name='activity_2',
     requires=[activity_1],
-    tasks=runner.Async(
+    runner=runner.Async(),
+    tasks=[
         lambda activity, context:
             print('activity_2_task_1'),
         lambda activity, context:
-            print('activity_2_task_2')))
+            print('activity_2_task_2')])
 
 activity_3 = create(
     name='activity_3',
     requires=[activity_1],
-    tasks=runner.Sync(
+    runner=runner.Sync(),
+    tasks=[
         lambda activity, context:
-            print('activity_3')))
+            print('activity_3')])
 
 activity_4 = create(
     name='activity_4',
     requires=[activity_3, activity_2],
-    tasks=runner.Sync(
+    runner=runner.Sync(),
+    tasks=[
         lambda activity, context:
-            print('activity_4')))
+            print('activity_4')])

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -152,7 +152,8 @@ def test_execute_activity(monkeypatch):
     custom_task = MagicMock(return_value=resp)
 
     current_activity = activity.Activity()
-    current_activity.tasks = runner.Sync(custom_task)
+    current_activity.runner = runner.Sync()
+    current_activity.tasks = [custom_task]
 
     val = current_activity.execute_activity(dict(foo='bar'))
 
@@ -166,11 +167,11 @@ def test_hydrate_activity(monkeypatch):
 
     monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
     current_activity = activity.Activity()
-    current_activity.hydrate(dict(
+    current_activity.hydrate(
         name='activity',
         domain='domain',
         requires=[],
-        tasks=[lambda: dict('val')]))
+        tasks=[lambda: dict('val')])
 
 
 def test_create_activity_worker(monkeypatch):


### PR DESCRIPTION
One of the recent request was to move the runner out, so you could write:
`create(..., runner=Sync(), tasks=[list of tasks])`

Still unsure if we should move forward with this implementation. The runner object will
always have a strong dependency on the tasks it runs. Another alternative would be to
have a `run` method instead that takes a runner and a list of tasks.