### PR TITLE
Switch `tasks` with `run`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ test_activity_1 = create(
 test_activity_2 = create(
     name='activity_2',
     requires=[test_activity_1],
-    tasks=runner.Async(
+    run=runner.Async(
         lambda activity, context: print('activity_2_task_1'),
         lambda activity, context: print('activity_2_task_2')))
 
 test_activity_3 = create(
     name='activity_3',
     requires=[test_activity_1],
-    tasks=runner.Sync(
+    run=runner.Sync(
         lambda activity, context: print('activity_3')))
 
 test_activity_4 = create(
     name='activity_4',
     requires=[test_activity_3, test_activity_2],
-    tasks=runner.Sync(
-    lambda activity, context: print('activity_4')))
+    run=runner.Sync(
+        lambda activity, context: print('activity_4')))
 ```
 
 ### Application architecture

--- a/example/test_flow.py
+++ b/example/test_flow.py
@@ -23,13 +23,13 @@ def activity_failure(activity, context):
 
 test_activity_1 = create(
     name='o',
-    tasks=runner.Sync(
+    run=runner.Sync(
         lambda activity, context: logger.debug('activity_1')))
 
 test_activity_2 = create(
     name='activity_2',
     requires=[test_activity_1],
-    tasks=runner.Async(
+    run=runner.Async(
         lambda activity, context: logger.debug('activity_2_task_1'),
         lambda activity, context: logger.debug('activity_2_task_2')))
 
@@ -37,10 +37,10 @@ test_activity_3 = create(
     name='activity_3',
     retry=10,
     requires=[test_activity_1],
-    tasks=runner.Sync(activity_failure))
+    run=runner.Sync(activity_failure))
 
 test_activity_4 = create(
     name='activity_4',
     requires=[test_activity_3, test_activity_2],
-    tasks=runner.Sync(
+    run=runner.Sync(
         lambda activity, context: logger.debug('activity_4')))

--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -22,8 +22,8 @@ Create an activity::
         # Name of your activity
         name='activity_name',
 
-        # List of tasks (here we use the Sync runner)
-        tasks=runner.Sync(task1),
+        # List of tasks to run (here we use the Sync runner)
+        run=runner.Sync(task1),
 
         # No requires since it's the first one. Later in your flow, if you have
         # a dependency, just use the variable that contains the activity.
@@ -149,13 +149,13 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
         return True
 
     def execute_activity(self, context):
-        """Execute the tasks within the activity.
+        """Execute the runner.
 
         Args:
             context (dict): The flow context.
         """
 
-        return self.tasks.execute(self, context)
+        return self.runner.execute(self, context)
 
     def hydrate(self, data):
         """Hydrate the task with information provided.
@@ -169,7 +169,13 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
         self.requires = getattr(self, 'requires', []) or data.get('requires')
         self.retry = getattr(self, 'retry', None) or data.get('retry', 0)
         self.task_list = self.task_list or data.get('task_list')
-        self.tasks = getattr(self, 'tasks', []) or data.get('tasks')
+
+        # The previous way to create an activity was to fill a `tasks` param,
+        # which is not `run`.
+        self.runner = (
+            getattr(self, 'runner', None) or
+                data.get('run') or data.get('tasks'))
+
         self.generators = getattr(
             self, 'generators', None) or data.get('generators')
 
@@ -221,7 +227,7 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
             int: Task list timeout.
         """
 
-        return self.tasks.timeout
+        return self.runner.timeout
 
 
 class ActivityWorker():
@@ -289,7 +295,8 @@ def create(domain):
             requires=options.get('requires', []),
             retry=options.get('retry'),
             task_list=domain + '_' + options.get('name'),
-            tasks=options.get('tasks', [])
+            tasks=options.get('tasks'),
+            run=options.get('run'),
         ))
         return activity
     return wrapper

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -152,7 +152,7 @@ def test_execute_activity(monkeypatch):
     custom_task = MagicMock(return_value=resp)
 
     current_activity = activity.Activity()
-    current_activity.tasks = runner.Sync(custom_task)
+    current_activity.runner = runner.Sync(custom_task)
 
     val = current_activity.execute_activity(dict(foo='bar'))
 


### PR DESCRIPTION
Just some changes in the naming. Passing `tasks=` does not really reflect the fact
that we are passing a runner. So instead, we will be using `run` (which is self explanatory)

@rantonmattei