### PR TITLE
Fix: when activity is not present on the task.

### DIFF
--- a/garcon/task.py
+++ b/garcon/task.py
@@ -103,11 +103,10 @@ def contextify(fn):
     def fill(namespace=None, **requirements):
 
         def wrapper(context, **kwargs):
-            kwargs.update(
-                fill_function_call(
-                    fn, requirements, kwargs.get('activity'), context))
+            options = fill_function_call(
+                fn, requirements, kwargs.get('activity'), context)
 
-            response = fn(**kwargs)
+            response = fn(**options)
             if not response or not namespace:
                 return response
 


### PR DESCRIPTION
When the activity is not present as a param in the task list, the
activity fails – it should instead succeed.

@rantonmattei 