### PR TITLE
Update the task decoration.

### DIFF
--- a/garcon/task.py
+++ b/garcon/task.py
@@ -73,6 +73,26 @@ def _decorate(fn, key=None, value=None):
         })
 
 
+def _link_decorator(source_fn, dest_fn):
+    """Link the garcon decorator values between two methods.
+
+    If the destination method already have a value on `__garcon__`, we get it
+    and merge it with the other one (so no values are lost.)
+
+    Args:
+        source_fn (callable): The method that contains `__garcon__`.
+        dest_fn (callable): The method that receives the decorator.
+    """
+
+    source_values = getattr(source_fn, '__garcon__', dict())
+
+    if hasattr(dest_fn, '__garcon__'):
+        source_values.update(dest_fn.__garcon__)
+
+    setattr(dest_fn, '__garcon__', source_values)
+    setattr(source_fn, '__garcon__', source_values)
+
+
 def contextify(fn):
     """Decorator to take values from the context and apply them to fn.
 
@@ -115,6 +135,7 @@ def contextify(fn):
 
         # Keep a record of the requirements value. This allows us to trim the
         # size of the context sent to the activity as an input.
+        _link_decorator(fn, wrapper)
         _decorate(wrapper, 'requirements', requirements.values())
         return wrapper
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -41,6 +41,43 @@ def test_decorator():
     assert test.__garcon__.get('foo') is 'bar'
 
 
+def test_link_decorator():
+    """Test linking the decorator between two methods.
+    """
+
+    def testA():
+        pass
+
+    def testB():
+        pass
+
+    task._decorate(testA, 'foo', 'value')
+    task._link_decorator(testA, testB)
+    assert testA.__garcon__ is testB.__garcon__
+    assert testA.__garcon__.get('foo') == 'value'
+    assert testB.__garcon__.get('foo') == 'value'
+
+
+def test_link_decorator_with_empty_source():
+    """Test linking decorators when garcon is not set on the source.
+    """
+
+    def testA():
+        pass
+
+    def testB():
+        pass
+
+    task._link_decorator(testA, testB)
+    assert testA.__garcon__ is testB.__garcon__
+    assert len(testA.__garcon__) is 0
+    assert len(testB.__garcon__) is 0
+
+    task._decorate(testB, 'foo', 'value')
+    task._link_decorator(testA, testB)
+    assert testA.__garcon__.get('foo') == 'value'
+
+
 def test_task_decorator():
     """Test the task decorator.
     """


### PR DESCRIPTION
If the task sets the timeout and contextify, the timeout stays on the original method,
not the contextify wrapper. Calling `.fill` ends up removing the `timeout`. Sharing the `_garcon_`
dictionary between the two methods solves this issue.

@rantonmattei