### PR TITLE
Add heartbeat.

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -261,6 +261,20 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
 
         return self.runner.timeout
 
+    @property
+    def heartbeat_timeout(self):
+        """Return the heartbeat in seconds.
+
+        This heartbeat corresponds on when an activity needs to send a signal
+        to swf that it is still running. This will set the value when the
+        activity is scheduled.
+
+        Return:
+            int: Task list timeout.
+        """
+
+        return self.runner.heartbeat
+
 
 class ActivityWorker():
 

--- a/garcon/decider.py
+++ b/garcon/decider.py
@@ -173,6 +173,7 @@ class DeciderWorker(swf.Decider):
                     self.version,
                     task_list=current.activity_worker.task_list,
                     input=json.dumps(current.create_execution_input(context)),
+                    heartbeat_timeout=current.activity_worker.heartbeat_timeout,
                     start_to_close_timeout=current.activity_worker.timeout)
             else:
                 activities = list(

--- a/garcon/task.py
+++ b/garcon/task.py
@@ -20,13 +20,13 @@ Note:
 import copy
 
 
-def decorate(timeout=None, enable_contextify=True):
+def decorate(timeout=None, heartbeat=None, enable_contextify=True):
     """Generic task decorator for tasks.
 
     Args:
         timeout (int): The timeout of the task (see timeout).
+        heartbeat (int): The heartbeat timeout.
         contextify (boolean): If the task can be contextified (see contextify).
-
     Return:
         callable: The wrapper.
     """
@@ -35,23 +35,31 @@ def decorate(timeout=None, enable_contextify=True):
         if timeout:
             _decorate(fn, 'timeout', timeout)
 
+        # If the task does not have a heartbeat, but instead the task has
+        # a timeout, the heartbeat should be adjusted to the timeout. In
+        # most case, most people will probably opt for this option.
+        if heartbeat or timeout:
+            _decorate(fn, 'heartbeat', heartbeat or timeout)
+
         if enable_contextify:
             contextify(fn)
-
         return fn
 
     return wrapper
 
 
-def timeout(time):
+def timeout(time, heartbeat=None):
     """Wrapper for a task to define its timeout.
 
     Args:
         time (int): the timeout in seconds
+        heartbeat (int): the heartbeat timeout (in seconds too.)
     """
 
     def wrapper(fn):
         _decorate(fn, 'timeout', time)
+        if heartbeat:
+            _decorate(fn, 'heartbeat', heartbeat)
         return fn
 
     return wrapper

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -148,6 +148,8 @@ def test_execute_activity(monkeypatch):
     """
 
     monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
+    monkeypatch.setattr(activity.Activity, 'heartbeat', lambda self: None)
+
     resp = dict(task_resp='something')
     custom_task = MagicMock(return_value=resp)
 

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -35,6 +35,7 @@ def test_create_decider(monkeypatch):
     dec = decider.DeciderWorker(example, register=False)
     assert not dec.register.called
 
+
 def test_get_workflow_execution_info(monkeypatch):
     """Check that the workflow execution info are properly extracted
     """

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -21,6 +21,21 @@ def test_timeout_decorator():
     assert test.__garcon__.get('timeout') == timeout
 
 
+def test_timeout_decorator_with_heartbeat():
+    """Test the timeout decorator with heartbeat.
+    """
+
+    timeout = 20
+    heartbeat = 30
+
+    @task.timeout(timeout, heartbeat=heartbeat)
+    def test():
+        pass
+
+    assert test.__garcon__.get('heartbeat') == heartbeat
+    assert test.__garcon__.get('timeout') == timeout
+
+
 def test_decorator():
     """Test the Decorator.
 
@@ -88,10 +103,24 @@ def test_task_decorator():
         assert user is userinfo
 
     assert test.__garcon__.get('timeout') == timeout
+    assert test.__garcon__.get('heartbeat') == timeout
     assert callable(test.fill)
 
     call = test.fill(user='user')
     call(dict(user='something'))
+
+
+def test_task_decorator_with_heartbeat():
+    """Test the task decorator with heartbeat.
+    """
+
+    heartbeat = 50
+
+    @task.decorate(heartbeat=heartbeat)
+    def test(user):
+        assert user is userinfo
+
+    assert test.__garcon__.get('heartbeat') == heartbeat
 
 
 def test_task_decorator_with_activity():


### PR DESCRIPTION
Heartbeat is set by default by AWS (to 600 seconds, which is
10 minutes. If an activity last longer than 10 minutes but
does not issue a heartbeat - SWF considers this activity has
failed.

The heartbeat mechanism works on our end at task level. We
gather all the different heartbeats (if one activity misses
the heartbeat, it is set to the SWF default.) – and figure
out which one is the longuest. We use this one as a
reference for our task.

Additional notes:
* Everytime an activity spawns a new task, the heartbeat is
triggered.
* Everytime an activity finishes a task, a heartbeat is
triggered (this is for the async task runner.)

@rantonmattei