### PR TITLE
Add the schedule_to_start and schedule_to_close timeouts.

### DIFF
--- a/garcon/decider.py
+++ b/garcon/decider.py
@@ -174,7 +174,12 @@ class DeciderWorker(swf.Decider):
                     task_list=current.activity_worker.task_list,
                     input=json.dumps(current.create_execution_input(context)),
                     heartbeat_timeout=current.activity_worker.heartbeat_timeout,
-                    start_to_close_timeout=current.activity_worker.timeout)
+                    start_to_close_timeout=str(
+                        current.activity_worker.timeout),
+                    schedule_to_start_timeout=str(
+                        current.activity_worker.schedule_to_start),
+                    schedule_to_close_timeout=str(
+                        current.activity_worker.schedule_to_close))
             else:
                 activities = list(
                     activity.find_uncomplete_activities(


### PR DESCRIPTION
Those two timeouts are calculated based on the assumption that only one
worker per activity. So if the user has set the create of the activity
to be 10 minutes and a generator spawns 10 activities, the schedule to start
will be 100 minutes.

Schedule to close timeout is an addition of schedule to start and start to
close timeout.

@rantonmattei