### PR TITLE
Fix instance context.

### DIFF
--- a/garcon/decider.py
+++ b/garcon/decider.py
@@ -172,7 +172,7 @@ class DeciderWorker(swf.Decider):
                     current.activity_name,
                     self.version,
                     task_list=current.activity_worker.task_list,
-                    input=json.dumps(current.create_execution_input(context)),
+                    input=json.dumps(current.create_execution_input()),
                     heartbeat_timeout=str(current.heartbeat_timeout),
                     start_to_close_timeout=str(current.timeout),
                     schedule_to_start_timeout=str(current.schedule_to_start),


### PR DESCRIPTION
The issue:

> The instance context is only representing the generator context.
> If this context is passed to the task.list, this context will appear
> empty.

Fix:

> Provide the execution context gathered by the decider to fill the
> necessary information

@rantonmattei