### PR TITLE
Add Param.

### DIFF
--- a/garcon/param.py
+++ b/garcon/param.py
@@ -1,0 +1,123 @@
+"""
+Param
+=====
+
+Params are values that are passed to the activities. They are either provided
+by the execution context (see Param) or are statically provided at the runtime
+of the activity (see StaticParam). Custom params should extend the Param class.
+
+Note:
+    Make sure the custom param class lists out all the dependencies to the
+    execution context in `requirements`.
+"""
+
+
+class BaseParam:
+    """Base Param Class.
+
+    Provides the structure and required methods of any param class.
+    """
+
+    @property
+    def requirements(self):
+        """Return the requirements for this param.
+        """
+
+        return
+        yield
+
+    def get_data(self, context):
+        """Get the data.
+
+        Args:
+            context (dict): the context (optional) in which the data might be
+                found. For Static Param this won't be necessary.
+        """
+
+        raise NotImplementedError()
+
+
+class Param(BaseParam):
+
+    def __init__(self, context_key):
+        """Create a default param.
+
+        Args:
+            context_key (str): the context key.
+        """
+
+        self.context_key = context_key
+
+    @property
+    def requirements(self):
+        """Return the requirements for this param.
+        """
+
+        yield self.context_key
+
+    def get_data(self, context):
+        """Get value from the context.
+
+        Args:
+            context (dict): the context in which the data might be found based
+                on the key provided.
+
+        Return:
+            obj: an object from the context that corresponds to the context
+                key.
+        """
+
+        return context.get(self.context_key, None)
+
+
+class StaticParam(BaseParam):
+
+    def __init__(self, value):
+        """Create a static param.
+
+        Args:
+            value (str): the value of the param.
+        """
+
+        self.value = value
+
+    def get_data(self, context):
+        """Get value from the context.
+
+        Args:
+            context (dict): execution context (not used.)
+        """
+
+
+        return self.value
+
+
+def get_all_requirements(params):
+    """Get all the requirements from a list of params.
+
+    Args:
+        params (list): The list of params.
+    """
+
+    requirements = []
+    for param in params:
+        requirements += list(param.requirements)
+    return requirements
+
+
+def parametrize(requirement):
+    """Parametrize a requirement.
+
+    Args:
+        requirement (*): the requirement to parametrize.
+    """
+
+    if isinstance(requirement, str):
+        return Param(requirement)
+    elif isinstance(requirement, BaseParam):
+        return requirement
+    raise UnknownParamException()
+
+
+class UnknownParamException(Exception):
+    pass

--- a/garcon/task.py
+++ b/garcon/task.py
@@ -19,6 +19,8 @@ Note:
 
 import copy
 
+from garcon import param
+
 
 def decorate(timeout=None, heartbeat=None, enable_contextify=True):
     """Generic task decorator for tasks.
@@ -167,6 +169,10 @@ def contextify(fn):
 
     def fill(namespace=None, **requirements):
 
+        requirements = {
+            key: param.parametrize(current_param)
+            for key, current_param in requirements.items()}
+
         def wrapper(context, **kwargs):
             kwargs.update(
                 fill_function_call(
@@ -181,7 +187,10 @@ def contextify(fn):
         # Keep a record of the requirements value. This allows us to trim the
         # size of the context sent to the activity as an input.
         _link_decorator(fn, wrapper)
-        _decorate(wrapper, 'requirements', requirements.values())
+        _decorate(
+            wrapper,
+            'requirements',
+            param.get_all_requirements(requirements.values()))
         return wrapper
 
     fn.fill = fill
@@ -228,7 +237,8 @@ def fill_function_call(fn, requirements, activity, context):
     kwargs = dict()
 
     for argument in function_arguments:
-        value = context.get(requirements.get(argument))
+        param = requirements.get(argument, None)
+        value = None
 
         if argument == 'context':
             raise Exception(
@@ -237,6 +247,9 @@ def fill_function_call(fn, requirements, activity, context):
 
         elif argument == 'activity':
             value = activity
+
+        elif param:
+            value = param.get_data(context)
 
         kwargs.update({
             argument: value

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1,0 +1,77 @@
+import pytest
+
+from garcon import param
+
+
+def test_base_param_class():
+    """Test the base class: cannot get data and return no requirements.
+    """
+
+    current_param = param.BaseParam()
+    with pytest.raises(NotImplementedError):
+        current_param.get_data({})
+
+    assert not list(current_param.requirements)
+
+
+def test_static_param():
+    """Test the behavior of the static param class
+    """
+
+    message = 'Hello World'
+    current_param = param.StaticParam(message)
+    assert current_param.get_data({}) is message
+    assert not list(current_param.requirements)
+
+
+def test_default_param():
+    """Test the behavior of the default param class.
+    """
+
+    key = 'context.key'
+    message = 'Hello World'
+    current_param = param.Param(key)
+    requirements = list(current_param.requirements)
+    assert current_param.get_data({key: message}) is message
+    assert requirements[0] is key
+
+
+def test_all_requirements():
+    """Test getting all the requirements.
+    """
+
+    keys = ['context.key1', 'context.key2', 'context.key3']
+    manual_keys = ['context.manual_key1', 'context.manual_key2']
+    params = [param.Param(key) for key in keys]
+    params += manual_keys
+    params += [param.StaticParam('Value')]
+    params = [param.parametrize(current_param) for current_param in params]
+
+    resp = param.get_all_requirements(params)
+    for key in keys:
+        assert key in resp
+
+    for manual_key in manual_keys:
+        assert manual_key in resp
+
+    assert 'Value' not in resp
+
+
+def test_parametrize():
+    """Test parametrize.
+
+    Parametrize only allows objects that inherits BaseParam or string.
+    """
+
+    keys = ['context.key1', 'context.key2', 'context.key3']
+    manual_keys = ['context.manual_key1', 'context.manual_key2']
+    params = [param.Param(key) for key in keys]
+    params += manual_keys
+    params += [param.StaticParam('Value')]
+    params = [param.parametrize(current_param) for current_param in params]
+
+    for current_param in params:
+        assert isinstance(current_param, param.BaseParam)
+
+    with pytest.raises(param.UnknownParamException):
+        param.parametrize(list('Unknown'))

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -7,6 +7,7 @@ except:
 import pytest
 
 from garcon import task
+from garcon import param
 
 
 def test_timeout_decorator():
@@ -301,7 +302,9 @@ def test_fill_function_call():
     def test_function(activity, arg_one, key, kwarg_one=None, kwarg_two=None):
         pass
 
-    requirements = dict(arg_one='context.arg', kwarg_one='context.kwarg')
+    requirements = dict(
+        arg_one=param.Param('context.arg'),
+        kwarg_one=param.Param('context.kwarg'))
     activity = None
     context = {
         'context.arg': 'arg.value',


### PR DESCRIPTION
Not all the values that needs to be passed to the tasks are from the context, they could be values
that are part of the flow configuration, and values that should not need to be sent to AWS (for
instance: database credentials.)

This features allows to parametrize the fill. You can use: StaticParam or Param. Param is the
default behavior, and StaticParam is a value passed to the activity without sending it to SWF.
Note: this is not compatible with external activities, external activities can only consume
values that have been sent to SWF.

Retrocompatibility is ensured: all value strings are turned into Param.

Example:

```python
    print_country_id.fill(
        country_id=param.Param('generator.country_id'),
        static=param.StaticParam('Hello World'))
```
@rantonmattei