### PR TITLE
Add Exception handlers.

### DIFF
--- a/garcon/event.py
+++ b/garcon/event.py
@@ -52,7 +52,8 @@ def activity_states_from_events(events):
 
             activity_events.setdefault(
                 activity_event.get('activity_name'), {}).setdefault(
-                    activity_id, activity.ActivityState(activity_id)).add_state(
+                    activity_id,
+                    activity.ActivityState(activity_id)).add_state(
                         activity.ACTIVITY_FAILED)
 
         elif event_type == 'ActivityTaskCompleted':
@@ -63,7 +64,8 @@ def activity_states_from_events(events):
 
             activity_events.setdefault(
                 activity_event.get('activity_name'), {}).setdefault(
-                    activity_id, activity.ActivityState(activity_id)).add_state(
+                    activity_id,
+                    activity.ActivityState(activity_id)).add_state(
                         activity.ACTIVITY_COMPLETED)
 
             result = json.loads(activity_info.get('result') or '{}')

--- a/tests/fixtures/flows/example.py
+++ b/tests/fixtures/flows/example.py
@@ -36,3 +36,12 @@ activity_4 = create(
     tasks=runner.Sync(
         lambda activity, context:
             print('activity_4')))
+
+
+def on_exception(actor, exception):
+    """Handler for exceptions.
+
+    Useful if you use sentry or other similar systems.
+    """
+
+    print(exception)

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -30,6 +30,7 @@ def test_create_decider(monkeypatch):
     assert len(d.activities) == 4
     assert d.flow
     assert d.domain
+    assert d.on_exception
 
     monkeypatch.setattr(decider.DeciderWorker, 'register', MagicMock())
     d = decider.DeciderWorker(example)


### PR DESCRIPTION
The exception handler can be provided directly to the decider by adding a method
named `on_exception(actor, exception)` and / or to the `create` method. It allows
to perform an action after an error has happened (for instance: log the error
in sentry).

@rantonmattei