### PR TITLE
Add execution context to input when used

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -214,7 +214,7 @@ class ActivityInstance:
 
         AWS has a limit on the number of characters that can be used (32k). If
         you use the `task.decorate`, the data sent to the activity is optimized
-        to match the values of the context.
+        to match the values of the context as well as the execution context.
 
         Return:
             dict: the input to send to the activity.
@@ -227,6 +227,8 @@ class ActivityInstance:
                 value = self.global_context.get(requirement)
                 if value:
                     activity_input.update({requirement: value})
+
+            activity_input.update(self.execution_context.items())
 
         except runner.NoRunnerRequirementsFound:
             return self.global_context

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -555,12 +555,13 @@ def test_create_activity_instance_input(monkeypatch):
     activity_mock.name = 'activity'
     activity_mock.runner = runner.BaseRunner(task_a.fill(value='context'))
     instance = activity.ActivityInstance(
-        activity_mock, local_context=dict(context='yes'),
+        activity_mock, local_context=dict(context='yes', unused='no'),
         execution_context=dict(somemore='values'))
     resp = instance.create_execution_input()
 
-    assert len(resp) == 1
+    assert len(resp) == 2
     assert resp.get('context') == 'yes'
+    assert resp.get('somemore') == 'values'
 
 
 def test_create_activity_instance_input_without_decorate(monkeypatch):


### PR DESCRIPTION
Adding execution context when task decorated is used to fix issue with GarconLogger being unable to [domain].[workflow_id].[run_id] when task decorated is used. 

@xethorn @rantonmattei
