### PR TITLE
Remove full context from input.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
     - "2.7"
     - "3.4"
-
+env:
+    - BOTO_CONFIG=/tmp/nowhere
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements-py2.txt; fi
     - "pip install -r requirements.txt"

--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -228,10 +228,16 @@ class ActivityInstance:
                 if value:
                     activity_input.update({requirement: value})
 
-            activity_input.update(self.execution_context.items())
+            activity_input.update({
+                'execution.domain': self.global_context.get('execution.domain'),
+                'execution.run_id': self.global_context.get('execution.run_id'),
+                'execution.workflow_id': self.global_context.get(
+                    'execution.workflow_id')
+            })
 
         except runner.NoRunnerRequirementsFound:
             return self.global_context
+
         return activity_input
 
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -561,9 +561,13 @@ def test_create_activity_instance_input(monkeypatch):
         execution_context=dict(somemore='values'))
     resp = instance.create_execution_input()
 
-    assert len(resp) == 2
+    assert len(resp) == 4
     assert resp.get('context') == 'yes'
-    assert resp.get('somemore') == 'values'
+    assert 'somemore' not in resp
+    assert 'unused' not in resp
+    assert 'execution.domain' in resp
+    assert 'execution.run_id' in resp
+    assert 'execution.workflow_id' in resp
 
 
 def test_create_activity_instance_input_without_decorate(monkeypatch):


### PR DESCRIPTION
The default behavior should be to send only what an activity requires
to run, instead of sending the full context. This was added in #64, so
handpicking those values will solve the problem.

@someboredkiddo @rantonmattei 