### PR TITLE
Add error catching for Activity polling

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -75,7 +75,7 @@ def test_run_activity(monkeypatch, poll):
 
 
 def test_run_capture_exception(monkeypatch, poll):
-    """Run an activity with an exception raised.
+    """Run an activity with an exception raised during activity execution.
     """
 
     current_activity = activity_run(monkeypatch, poll=poll)
@@ -91,6 +91,28 @@ def test_run_capture_exception(monkeypatch, poll):
     assert current_activity.on_exception.called
     current_activity.fail.assert_called_with(reason=actual_error_msg)
     assert not current_activity.complete.called
+
+
+def test_run_capture_poll_exception(monkeypatch, poll):
+    """Run an activity with an exception raised during poll.
+    """
+
+    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity.on_exception = MagicMock()
+    current_activity.execute_activity = MagicMock()
+    exception = Exception('poll exception')
+    current_activity.poll.side_effect = exception
+    current_activity.run()
+
+    assert current_activity.poll.called
+    assert current_activity.on_exception.called
+    assert not current_activity.execute_activity.called
+    assert not current_activity.complete.called
+
+    current_activity.on_exception = None
+    current_activity.logger.error = MagicMock()
+    current_activity.run()
+    current_activity.logger.error.assert_called_with(exception, exc_info=True)
 
 
 def test_run_activity_without_id(monkeypatch):


### PR DESCRIPTION
hey @xethorn 

We noticed that occasionally AWS throttles during a worker/decider poll(), causing the thread running that worker for a particular activity to die.  Because there is no longer a worker for that activity, Workflows then get stuck when trying to execute that activity.

This initial PR adds a simple try | catch to avoid the daemon from dying. I'll make another after this to add some sort of sleep if the exception raised is related to throttling, as well as another one for the decider's poll() call.

see below for an example of the error message
```
2017-08-03 14:54:37,605 DEBG 'XXX-worker_00' stderr output:
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.4/site-packages/garcon/activity.py", line 516, in worker_runner
    while(worker.run()):
  File "/usr/local/lib/python3.4/site-packages/garcon/activity.py", line 256, in run
    activity_task = self.poll()
  File "/usr/local/lib/python3.4/site-packages/boto/swf/layer2.py", line 198, in poll
    **kwargs)
  File "/usr/local/lib/python3.4/site-packages/boto/swf/layer1.py", line 180, in poll_for_activity_task
    'identity': identity,
  File "/usr/local/lib/python3.4/site-packages/boto/swf/layer1.py", line 118, in json_request
    return self.make_request(action, json_input, object_hook)
  File "/usr/local/lib/python3.4/site-packages/boto/swf/layer1.py", line 145, in make_request
    raise excp_cls(response.status, response.reason, body=json_body)
boto.exception.SWFResponseError: SWFResponseError: 400 Bad Request
{'message': 'Rate exceeded', '__type': 'com.amazon.coral.availability#ThrottlingException'}
```