### PR TITLE
Add exponential backoff for Activity poll

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -38,6 +38,8 @@ Create an activity::
 """
 
 from threading import Thread
+import backoff
+import boto.exception as boto_exception
 import boto.swf.layer2 as swf
 import itertools
 import json
@@ -245,6 +247,24 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
     version = '1.0'
     task_list = None
 
+    @backoff.on_exception(
+        backoff.expo,
+        boto_exception.SWFResponseError,
+        max_tries=5,
+        giveup=utils.non_throttle_error,
+        on_backoff=utils.throttle_backoff_handler,
+        jitter=backoff.full_jitter)
+    def poll_for_activity(self):
+        """Runs Activity Poll.
+
+        If a SWF throttling exception is raised during a poll, the poll will
+        be retried up to 5 times using exponential backoff algorithm.
+
+        Upgrading to boto3 would make this retry logic redundant.
+        """
+
+        return self.poll()
+
     def run(self):
         """Activity Runner.
 
@@ -254,7 +274,7 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
         """
 
         try:
-            activity_task = self.poll()
+            activity_task = self.poll_for_activity()
         except Exception as error:
             # Catch exceptions raised during poll() to avoid an Activity thread
             # dying & worker daemon unable to process the affected Activity.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff==1.4.3
 boto==2.35.1
 pytest-cov==1.8.1
 pytest==2.6.4

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['boto'],
+    install_requires=['boto', 'backoff'],
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python :: 2.7',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,11 @@
-import pytest
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+import boto.exception as boto_exception
 import datetime
+import pytest
+import json
 
 from garcon import utils
 
@@ -21,7 +27,7 @@ def test_create_dictionary_key_with_empty_dict():
 
 
 def test_create_dictionary_key():
-    """Try craeting a unique key from a dict.
+    """Try creating a unique key from a dict.
     """
 
     values = [
@@ -30,3 +36,53 @@ def test_create_dictionary_key():
 
     for value in values:
         assert len(utils.create_dictionary_key(value)) == 40
+
+def test_create_dictionary_key():
+    """Try creating a unique key from a dict.
+    """
+
+    values = [
+        dict(foo=10),
+        dict(foo2=datetime.datetime.now())]
+
+    for value in values:
+        assert len(utils.create_dictionary_key(value)) == 40
+
+
+def test_non_throttle_error():
+    """Assert SWF error is evaluated as non-throttle error properly.
+    """
+
+    response_status = 400
+    response_reason = 'Bad Request'
+    reponse_body = (
+        '{"__type": "com.amazon.coral.availability#ThrottlingException",'
+        '"message": "Rate exceeded"}')
+    json_body = json.loads(reponse_body)
+    exception = boto_exception.SWFResponseError(
+        response_status, response_reason, body=json_body)
+    result = utils.non_throttle_error(exception)
+    assert not utils.non_throttle_error(exception)
+
+    reponse_body = (
+        '{"__type": "com.amazon.coral.availability#OtheException",'
+        '"message": "Rate exceeded"}')
+    json_body = json.loads(reponse_body)
+    exception = boto_exception.SWFResponseError(
+        response_status, response_reason, body=json_body)
+    assert utils.non_throttle_error(exception)
+
+def test_throttle_backoff_handler():
+    """Assert backoff is logged correctly.
+    """
+
+    mock_activity = MagicMock()
+    details = dict(
+        args=(mock_activity,),
+        tries=5,
+        wait=10)
+    utils.throttle_backoff_handler(details)
+    mock_activity.logger.info.assert_called_with(
+        'Throttle Exception occurred on try {}. '
+        'Sleeping for {} seconds'.format(
+            details['tries'], details['wait']))


### PR DESCRIPTION
Add exponential backoff to deal with AWS SWF API throttles when polling

Note this is only required because boto2 does not implement exponential backoff on its own when making API calls to AWS. Upgrading to boto3 would resolve this.