### PR TITLE
Add workflow fail on activity timeout feature

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -246,6 +246,7 @@ class ActivityInstance:
 class Activity(swf.ActivityWorker, log.GarconLogger):
     version = '1.0'
     task_list = None
+    fail_on_timeout = None
 
     @backoff.on_exception(
         backoff.expo,
@@ -367,6 +368,8 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
 
         self.generators = getattr(
             self, 'generators', None) or data.get('generators')
+
+        self.fail_on_timeout = data.get('fail_on_timeout')
 
     def instances(self, context):
         """Get all instances for one activity based on the current context.
@@ -608,7 +611,8 @@ def create(domain, name, version='1.0', on_exception=None):
             tasks=options.get('tasks'),
             run=options.get('run'),
             schedule_to_start=options.get('schedule_to_start'),
-            on_exception=options.get('on_exception') or on_exception))
+            on_exception=options.get('on_exception') or on_exception,
+            fail_on_timeout=options.get('fail_on_timeout')))
         return activity
     return wrapper
 

--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -1,0 +1,103 @@
+history = [
+    {
+        'eventId': 1,
+        'eventTimestamp': 1530183236.437,
+        'eventType': 'WorkflowExecutionStarted',
+        'workflowExecutionStartedEventAttributes': {
+            'childPolicy': 'TERMINATE',
+            'executionStartToCloseTimeout': '3600',
+            'parentInitiatedEventId': 0,
+            'taskList': {'name': 'basic'},
+            'taskStartToCloseTimeout': '300',
+            'workflowType': {'name': 'basic', 'version': '1.0'}
+        }
+    },
+    {
+        'activityTaskScheduledEventAttributes':
+            {
+                'activityId': 'basic_activity_1-1',
+                'activityType':
+                    {
+                        'name': 'basic_activity_1',
+                        'version': '1.0'
+                    },
+                'decisionTaskCompletedEventId': 4,
+                'heartbeatTimeout': '600',
+                'input': '{"execution.domain": "MyTutorialDomain", "execution.workflow_id": "basic-1.0-1530183235", "execution.run_id": "22S4V/sVSQmLzQN1yk/4RVv6t3uLP5HOVd3qK1VYY9ZVo="}',
+                'scheduleToCloseTimeout': '1200',
+                'scheduleToStartTimeout': '600',
+                'startToCloseTimeout': '600',
+                'taskList': {'name': 'basic_activity_1'}
+            },
+        'eventId': 5,
+        'eventTimestamp': 1530183244.205,
+        'eventType': 'ActivityTaskScheduled'
+    },
+    {
+        'activityTaskStartedEventAttributes':
+            {
+                'scheduledEventId': 5
+            },
+        'eventId': 6,
+        'eventTimestamp': 1530183244.271,
+        'eventType': 'ActivityTaskStarted'
+    },
+    {
+        'activityTaskCompletedEventAttributes':
+            {
+                'result': '{"first_act_result": "file is downloaded"}',
+                'scheduledEventId': 5, 'startedEventId': 6
+            },
+        'eventId': 7,
+        'eventTimestamp': 1530183245.568,
+        'eventType': 'ActivityTaskCompleted'
+    },
+    {
+        'activityTaskScheduledEventAttributes':
+            {
+                'activityId': 'basic_activity_2-1',
+                'activityType': {'name': 'basic_activity_2', 'version': '1.0'},
+                'decisionTaskCompletedEventId': 10, 'heartbeatTimeout': '30',
+                'input': '{"execution.domain": "MyTutorialDomain", "execution.run_id": "22S4V/sVSQmLzQN1yk/4RVv6t3uLP5HOVd3qK1VYY9ZVo=", "execution.workflow_id": "basic-1.0-1530183235"}',
+                'scheduleToCloseTimeout': '630',
+                'scheduleToStartTimeout': '600',
+                'startToCloseTimeout': '30',
+                'taskList': {'name': 'basic_activity_2'}
+            },
+        'eventId': 11,
+        'eventTimestamp': 1530183247.589,
+        'eventType': 'ActivityTaskScheduled'
+    },
+    {
+        'activityTaskStartedEventAttributes': {'scheduledEventId': 11},
+        'eventId': 12,
+        'eventTimestamp': 1530183297.418,
+        'eventType': 'ActivityTaskStarted'
+    },
+    {
+        'activityTaskTimedOutEventAttributes':
+            {
+                'scheduledEventId': 11,
+                'startedEventId': 12,
+                'timeoutType': 'START_TO_CLOSE'
+            },
+        'eventId': 13,
+        'eventTimestamp': 1530183327.421,
+        'eventType': 'ActivityTaskTimedOut'
+    }
+]
+
+time_out_event = {
+    'activityTaskTimedOutEventAttributes':
+        {
+            'scheduledEventId': 11,
+            'startedEventId': 12,
+            'timeoutType': 'START_TO_CLOSE'
+        },
+    'eventId': 13,
+    'eventTimestamp': 1530183327.421,
+    'eventType': 'ActivityTaskTimedOut'
+}
+
+critical_activity_namelist = ['basic_activity_2']
+not_timed_out_activity = ['basic_activity_1']


### PR DESCRIPTION
### Description of the Change
This change adds the ability to immediately finish Workflow as failed when time-out event occurs during execution of the Activity with special parameter fail_on_timeout set to True.

### Verification Process
I wrote a simple test workflow to prove that this feature works as described.

### Example
In workflow script simply add "fail_on_timeout=True" to desired activity creator. 
```
from garcon import task

@task.timeout(time=60)
test_activity_1 = create(
    name='activity_1',
    fail_on_timeout=True,
    run=runner.Sync(
        lambda context, activity: logger.debug('activity_1')))
```