### PR TITLE
Migrate from boto2 to boto3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,24 @@
 language: python
-python:
-    - "2.7"
-    - "3.4"
+matrix:
+    include:
+        - python: 2.7
+          dist: trusty
+          sudo: false
+        - python: 3.3
+          dist: trusty
+          sudo: false
+        - python: 3.4
+          dist: trusty
+          sudo: false
+        - python: 3.5
+          dist: trusty
+          sudo: false
+        - python: 3.6
+          dist: trusty
+          sudo: false
+        - python: 3.7
+          dist: xenial
+          sudo: true
 env:
     - BOTO_CONFIG=/tmp/nowhere
 install:

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Lightweight library for AWS SWF.
 Requirements
 ~~~~~~~~~~~~
 
--  Python 2.7, 3.4 (tested)
--  Boto 2.34.0 (tested)
+-  Python 2.7, 3.4, 3.5, 3.6, 3.7 (tested)
+-  Boto3 (tested)
 
 Goal
 ~~~~
@@ -35,13 +35,15 @@ be completed.
 
     from __future__ import print_function
 
+    import boto3
     from garcon import activity
     from garcon import runner
 
+    client = boto3.client('swf', region_name='us-east-1')
 
     domain = 'dev'
     name = 'workflow_sample'
-    create = activity.create(domain, name)
+    create = activity.create(client, domain, name)
 
     test_activity_1 = create(
         name='activity_1',

--- a/example/custom_decider/workflow.py
+++ b/example/custom_decider/workflow.py
@@ -9,21 +9,20 @@ coffee shop.
 Workflow:
     1. Enter in the coffee shop.
     2. Order.
-        2.1 Chocolate chip cookie.
-        2.2 Coffee.
+        2.1 Coffee.
+        2.2 Chocolate chip cookie.
     3. Finalize the order (any of the activites below can be done in any order)
         3.1 Pays.
         3.2 Get the order.
     4. Leave the coffee shop.
 
 Result:
-
-entering coffee shop
-ordering: coffee
-ordering: chocolate_chip_cookie
-pay $6.98
-get order
-leaving the coffee shop
+    entering coffee shop
+    ordering: coffee
+    ordering: chocolate_chip_cookie
+    pay $6.98
+    get order
+    leaving the coffee shop
 """
 
 from garcon import activity
@@ -33,7 +32,7 @@ from garcon import task
 
 class Workflow:
 
-    def __init__(self, domain, name):
+    def __init__(self, client, domain, name):
         """Create the workflow.
 
         Args:
@@ -42,7 +41,8 @@ class Workflow:
         """
         self.name = name
         self.domain = domain
-        self.create_activity = activity.create(domain, name)
+        self.client = client
+        self.create_activity = activity.create(client, domain, name)
 
     def decider(self, schedule, context=None):
         """Custom deciders.

--- a/example/simple/workflow.py
+++ b/example/simple/workflow.py
@@ -1,16 +1,15 @@
-import boto.swf.layer2 as swf
-
 from garcon import activity
 from garcon import runner
+import boto3
 import logging
 import random
 
 
 logger = logging.getLogger(__name__)
-
+client = boto3.client('swf', region_name='us-east-1')
 domain = 'dev'
 name = 'workflow_sample'
-create = activity.create(domain, name)
+create = activity.create(client, domain, name)
 
 
 def activity_failure(context, activity):
@@ -18,8 +17,7 @@ def activity_failure(context, activity):
     if num != 3:
         logger.warn('activity_3: fails')
         raise Exception('fails')
-
-    print('activity_3: end')
+    logger.debug('activity_3: end')
 
 
 test_activity_1 = create(

--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -13,10 +13,12 @@ you should create a main task that will then split the work.
 
 Create an activity::
 
+    import boto3
     from garcon import activity
 
     # First step is to create the workflow on a specific domain.
-    create = activity.create('domain')
+    client = boto3.client('swf')
+    create = activity.create(client, 'domain', 'workflow-name')
 
     initial_activity = create(
         # Name of your activity
@@ -37,17 +39,15 @@ Create an activity::
 
 """
 
-import backoff
-import boto.exception as boto_exception
-import boto.swf.layer2 as swf
+from botocore import exceptions
 import itertools
 import json
 import threading
+import backoff
 
 from garcon import log
 from garcon import utils
 from garcon import runner
-
 
 ACTIVITY_STANDBY = 0
 ACTIVITY_SCHEDULED = 1
@@ -243,13 +243,25 @@ class ActivityInstance:
         return activity_input
 
 
-class Activity(swf.ActivityWorker, log.GarconLogger):
+class Activity(log.GarconLogger):
     version = '1.0'
     task_list = None
 
+    def __init__(self, client):
+        """Instantiates an activity.
+
+        Args:
+            client: the boto client used for this activity.
+        """
+
+        self.client = client
+        self.name = None
+        self.domain = None
+        self.task_list = None
+
     @backoff.on_exception(
         backoff.expo,
-        boto_exception.SWFResponseError,
+        exceptions.ClientError,
         max_tries=5,
         giveup=utils.non_throttle_error,
         on_backoff=utils.throttle_backoff_handler,
@@ -266,9 +278,22 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
             identity (str): Identity of the worker making the request, which
                 is recorded in the ActivityTaskStarted event in the AWS
                 console. This enables diagnostic tracing when problems arise.
+        Return:
+            ActivityExecution: activity execution.
         """
 
-        return self.poll(identity=identity)
+        additional_params = {}
+        if identity:
+            additional_params.update(identity=identity)
+
+        execution_definition = self.client.poll_for_activity_task(
+            domain=self.domain, taskList=dict(name=self.task_list),
+            **additional_params)
+
+        return ActivityExecution(
+            self.client, execution_definition.get('activityId'),
+            execution_definition.get('taskToken'),
+            execution_definition.get('input'))
 
     def run(self, identity=None):
         """Activity Runner.
@@ -278,15 +303,14 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
         previous activity is consumed (context).
 
         Args:
-            activity_id (str): Identity of the worker making the request, which
+            identity (str): Identity of the worker making the request, which
                 is recorded in the ActivityTaskStarted event in the AWS
                 console. This enables diagnostic tracing when problems arise.
         """
-
         try:
             if identity:
                 self.logger.debug('Polling with {}'.format(identity))
-            activity_task = self.poll_for_activity(identity)
+            execution = self.poll_for_activity(identity)
         except Exception as error:
             # Catch exceptions raised during poll() to avoid an Activity thread
             # dying & worker daemon unable to process the affected Activity.
@@ -297,27 +321,20 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
             # when an exception occurs.
             if self.on_exception:
                 self.on_exception(self, error)
-
             self.logger.error(error, exc_info=True)
             return True
 
-        packed_context = activity_task.get('input')
-        context = dict()
-
-        if packed_context:
-            context = json.loads(packed_context)
-            self.set_log_context(context)
-
-        if 'activityId' in activity_task:
+        self.set_log_context(execution.context)
+        if execution.activity_id:
             try:
-                context = self.execute_activity(context)
-                self.complete(result=json.dumps(context))
+                context = self.execute_activity(execution)
+                execution.complete(context)
             except Exception as error:
                 # If the workflow has been stopped, it is not possible for the
                 # activity to be updated – it throws an exception which stops
                 # the worker immediately.
                 try:
-                    self.fail(reason=str(error)[:255])
+                    execution.fail(str(error)[:255])
                     if self.on_exception:
                         self.on_exception(self, error)
                 except:
@@ -326,14 +343,17 @@ class Activity(swf.ActivityWorker, log.GarconLogger):
         self.unset_log_context()
         return True
 
-    def execute_activity(self, context):
+    def execute_activity(self, activity):
         """Execute the runner.
 
         Args:
-            context (dict): The flow context.
+            execution (ActivityExecution): the activity execution.
+
+        Return:
+            dict: The result of the operation.
         """
 
-        return self.runner.execute(self, context)
+        return self.runner.execute(activity, activity.context)
 
     def hydrate(self, data):
         """Hydrate the task with information provided.
@@ -428,6 +448,7 @@ class ExternalActivity(Activity):
                 will be equal to the timeout.
         """
 
+        Activity.__init__(self, client=None)
         self.runner = runner.External(timeout=timeout, heartbeat=heartbeat)
 
     def run(self):
@@ -438,6 +459,56 @@ class ExternalActivity(Activity):
         """
 
         return False
+
+
+class ActivityExecution:
+
+    def __init__(self, client, activity_id, task_token, context):
+        """Create an an activity execution.
+
+        Args:
+            client (boto3.client): the boto client (for easy access if needed).
+            activity_id (str): the activity id.
+            task_token (str): the task token.
+            context (str): data for the execution.
+        """
+
+        self.client = client
+        self.activity_id = activity_id
+        self.task_token = task_token
+        self.context = context and json.loads(context) or dict()
+
+    def heartbeat(self, details=None):
+        """Create a task heartbeat.
+
+        Args:
+            details (str): details to add to the heartbeat.
+        """
+
+        self.client.record_activity_task_heartbeat(self.task_token,
+            details=details or '')
+
+    def fail(self, reason=None):
+        """Mark the activity execution as failed.
+
+        Args:
+            reason (str): optional reason for the failure.
+        """
+
+        self.client.respond_activity_task_failed(
+            taskToken=self.task_token,
+            reason=reason or '')
+
+    def complete(self, context=None):
+        """Mark the activity execution as completed.
+
+        Args:
+            context (str or dict): the context result of the operation.
+        """
+
+        self.client.respond_activity_task_completed(
+            taskToken=self.task_token,
+            result=json.dumps(context))
 
 
 class ActivityWorker():
@@ -549,7 +620,7 @@ class ActivityState:
         """Wait until ready.
         """
 
-        if not self.ready():
+        if not self.ready:
             raise ActivityInstanceNotReadyException()
 
 
@@ -560,11 +631,11 @@ def worker_runner(worker):
         worker (object): the Activity worker.
     """
 
-    while(worker.run()):
+    while (worker.run()):
         continue
 
 
-def create(domain, name, version='1.0', on_exception=None):
+def create(client, domain, workflow_name, version='1.0', on_exception=None):
     """Helper method to create Activities.
 
     The helper method simplifies the creation of an activity by setting the
@@ -576,8 +647,9 @@ def create(domain, name, version='1.0', on_exception=None):
         activity. Always make sure your activity name is unique.
 
     Args:
+        client (boto3.client): the boto3 client.
         domain (str): the domain name.
-        name (str): name of the activity.
+        workflow_name (str): workflow name.
         version (str): activity version.
         on_exception (callable): the error handler.
 
@@ -586,7 +658,7 @@ def create(domain, name, version='1.0', on_exception=None):
     """
 
     def wrapper(**options):
-        activity = Activity()
+        activity = Activity(client)
 
         if options.get('external'):
             activity = ExternalActivity(
@@ -594,7 +666,7 @@ def create(domain, name, version='1.0', on_exception=None):
                 heartbeat=options.get('heartbeat'))
 
         activity_name = '{name}_{activity}'.format(
-            name=name,
+            name=workflow_name,
             activity=options.get('name'))
 
         activity.hydrate(dict(
@@ -610,6 +682,7 @@ def create(domain, name, version='1.0', on_exception=None):
             schedule_to_start=options.get('schedule_to_start'),
             on_exception=options.get('on_exception') or on_exception))
         return activity
+
     return wrapper
 
 
@@ -635,7 +708,7 @@ def find_available_activities(flow, history, context):
             if states.get_last_state() != ACTIVITY_FAILED:
                 continue
             elif (not instance.retry or
-                    instance.retry < count_activity_failures(states)):
+                  instance.retry < count_activity_failures(states)):
                 raise Exception(
                     'The activity failures has exceeded its retry limit.')
 

--- a/garcon/utils.py
+++ b/garcon/utils.py
@@ -30,18 +30,18 @@ def create_dictionary_key(dictionary):
 
     return hashlib.sha1(key_parts.encode('utf-8')).hexdigest()
 
-def non_throttle_error(swf_response_error):
+def non_throttle_error(exception):
     """Activity Runner.
 
     Determine whether SWF Exception was a throttle or a different error.
 
     Args:
-        error: boto.exception.SWFResponseError instance.
+        exception: botocore.exceptions.Client instance.
     Return:
-        bool: True if SWFResponseError was a throttle, False otherwise.
+        bool: True if exception was a throttle, False otherwise.
     """
 
-    return swf_response_error.error_code != 'ThrottlingException'
+    return exception.response.get('Error').get('Code') != 'ThrottlingException'
 
 def throttle_backoff_handler(details):
     """Callback to be used when a throttle backoff is invoked.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==1.4.3
-boto==2.35.1
-pytest-cov==1.8.1
-pytest==2.6.4
+boto3==1.7.58
+pytest-cov==2.5.1
+pytest==3.6.3
 python-coveralls==2.4.3
 tox==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,7 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+try:
+    from unittest.mock import MagicMock
+except:
+    from mock import MagicMock
+
+import pytest
+import boto3
+
+
+@pytest.fixture
+def boto_client(monkeypatch):
+    """Create a fake boto client."""
+    return MagicMock(spec=boto3.client('swf', region_name='us-east-1'))

--- a/tests/fixtures/flows/example.py
+++ b/tests/fixtures/flows/example.py
@@ -3,10 +3,12 @@ from __future__ import print_function
 from garcon import activity
 from garcon import runner
 
+import boto3
 
+client = boto3.client('swf', region_name='us-east-1')
 domain = 'dev'
 name = 'workflow_name'
-create = activity.create(domain, name)
+create = activity.create(client, domain, name)
 
 activity_1 = create(
     name='activity_1',

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -2,10 +2,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 try:
     from unittest.mock import MagicMock
+    from unittest.mock import ANY
 except:
     from mock import MagicMock
+    from mock import ANY
+from botocore import exceptions
 import json
 import pytest
+import sys
 
 from garcon import activity
 from garcon import event
@@ -14,28 +18,26 @@ from garcon import task
 from garcon import utils
 from tests.fixtures import decider
 
-import boto.exception as boto_exception
-
 
 def activity_run(
-        monkeypatch, poll=None, complete=None, fail=None, execute=None):
+        monkeypatch, boto_client, poll=None, complete=None, fail=None,
+        execute=None):
     """Create an activity.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-
-    current_activity = activity.Activity()
+    current_activity = activity.Activity(boto_client)
     poll = poll or dict()
 
     monkeypatch.setattr(
         current_activity, 'execute_activity',
         execute or MagicMock(return_value=dict()))
     monkeypatch.setattr(
-        current_activity, 'poll', MagicMock(return_value=poll))
+        boto_client, 'poll_for_activity_task', MagicMock(return_value=poll))
     monkeypatch.setattr(
-        current_activity, 'complete', complete or MagicMock())
+        boto_client, 'respond_activity_task_completed', complete or MagicMock())
     monkeypatch.setattr(
-        current_activity, 'fail', fail or MagicMock())
+        boto_client, 'respond_activity_task_failed', fail or MagicMock())
+
     return current_activity
 
 
@@ -61,104 +63,104 @@ def generators(request):
 
 @pytest.fixture
 def poll():
-    return dict(activityId='something')
+    return dict(
+        activityId='something',
+        taskToken='taskToken')
 
 
-def test_poll_for_activity(monkeypatch, poll=poll):
+def test_poll_for_activity(monkeypatch, poll, boto_client):
     """Test that poll_for_activity successfully polls.
     """
 
-    current_activity = activity_run(monkeypatch, poll)
-    current_activity.poll.return_value = 'foo'
+    activity_task = poll
+    current_activity = activity_run(monkeypatch, boto_client, poll)
+    boto_client.poll_for_activity_task.return_value = activity_task
 
-    activity_results = current_activity.poll_for_activity()
-    assert current_activity.poll.called
-    assert activity_results == 'foo'
+    activity_execution = current_activity.poll_for_activity()
+    assert boto_client.poll_for_activity_task.called
+    assert activity_execution.task_token is poll.get('taskToken')
 
 
-def test_poll_for_activity_throttle_retry(monkeypatch, poll=poll):
+def test_poll_for_activity_throttle_retry(monkeypatch, poll, boto_client):
     """Test that SWF throttles are retried during polling.
     """
 
-    current_activity = activity_run(monkeypatch, poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll)
+    boto_client.poll_for_activity_task.side_effect = exceptions.ClientError(
+        {'Error': {'Code': 'ThrottlingException'}},
+        'operation name')
 
-    response_status = 400
-    response_reason = 'Bad Request'
-    reponse_body = (
-        '{"__type": "com.amazon.coral.availability#ThrottlingException",'
-        '"message": "Rate exceeded"}')
-    json_body = json.loads(reponse_body)
-    exception = boto_exception.SWFResponseError(
-        response_status, response_reason, body=json_body)
-    current_activity.poll.side_effect = exception
-
-    with pytest.raises(boto_exception.SWFResponseError):
+    with pytest.raises(exceptions.ClientError):
         current_activity.poll_for_activity()
-    assert current_activity.poll.call_count == 5
+    assert boto_client.poll_for_activity_task.call_count == 5
 
 
-def test_poll_for_activity_error(monkeypatch, poll=poll):
+def test_poll_for_activity_error(monkeypatch, poll, boto_client):
     """Test that non-throttle errors during poll are thrown.
     """
 
-    current_activity = activity_run(monkeypatch, poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll)
 
     exception = Exception()
-    current_activity.poll.side_effect = exception
+    boto_client.poll_for_activity_task.side_effect = exception
 
     with pytest.raises(Exception):
         current_activity.poll_for_activity()
 
 
-def test_poll_for_activity_identity(monkeypatch, poll=poll):
+def test_poll_for_activity_identity(monkeypatch, poll, boto_client):
     """Test that identity is passed to poll_for_activity.
     """
 
-    current_activity = activity_run(monkeypatch, poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll)
 
     current_activity.poll_for_activity(identity='foo')
-    current_activity.poll.assert_called_with(identity='foo')
+    boto_client.poll_for_activity_task.assert_called_with(
+        domain=ANY, taskList=ANY, identity='foo')
 
 
-def test_poll_for_activity_no_identity(monkeypatch, poll=poll):
+def test_poll_for_activity_no_identity(monkeypatch, poll, boto_client):
     """Test poll_for_activity works without identity passed as param.
     """
 
-    current_activity = activity_run(monkeypatch, poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll)
 
     current_activity.poll_for_activity()
-    current_activity.poll.assert_called_with(identity=None)
+    boto_client.poll_for_activity_task.assert_called_with(
+        domain=ANY, taskList=ANY)
 
 
-def test_run_activity(monkeypatch, poll):
+def test_run_activity(monkeypatch, poll, boto_client):
     """Run an activity.
     """
 
-    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll)
     current_activity.run()
 
-    current_activity.poll.assert_called_with(identity=None)
+    boto_client.poll_for_activity_task.assert_called_with(
+        domain=ANY, taskList=ANY)
     assert current_activity.execute_activity.called
-    assert current_activity.complete.called
+    assert boto_client.respond_activity_task_completed.called
 
 
-def test_run_activity_identity(monkeypatch, poll):
+def test_run_activity_identity(monkeypatch, poll, boto_client):
     """Run an activity with identity as param.
     """
 
-    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll)
     current_activity.run(identity='foo')
 
-    current_activity.poll.assert_called_with(identity='foo')
+    boto_client.poll_for_activity_task.assert_called_with(
+        domain=ANY, taskList=ANY, identity='foo')
     assert current_activity.execute_activity.called
-    assert current_activity.complete.called
+    assert boto_client.respond_activity_task_completed.called
 
 
-def test_run_capture_exception(monkeypatch, poll):
+def test_run_capture_exception(monkeypatch, poll, boto_client):
     """Run an activity with an exception raised during activity execution.
     """
 
-    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll)
     current_activity.on_exception = MagicMock()
     current_activity.execute_activity = MagicMock()
     error_msg_long = "Error" * 100
@@ -166,28 +168,32 @@ def test_run_capture_exception(monkeypatch, poll):
     current_activity.execute_activity.side_effect = Exception(error_msg_long)
     current_activity.run()
 
-    assert current_activity.poll.called
+    assert boto_client.poll_for_activity_task.called
     assert current_activity.execute_activity.called
     assert current_activity.on_exception.called
-    current_activity.fail.assert_called_with(reason=actual_error_msg)
-    assert not current_activity.complete.called
+    boto_client.respond_activity_task_failed.assert_called_with(
+        taskToken=poll.get('taskToken'),
+        reason=actual_error_msg)
+    assert not boto_client.respond_activity_task_completed.called
 
 
-def test_run_capture_poll_exception(monkeypatch, poll):
+def test_run_capture_poll_exception(monkeypatch, boto_client, poll):
     """Run an activity with an exception raised during poll.
     """
 
-    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll)
+
     current_activity.on_exception = MagicMock()
     current_activity.execute_activity = MagicMock()
+
     exception = Exception('poll exception')
-    current_activity.poll.side_effect = exception
+    boto_client.poll_for_activity_task.side_effect = exception
     current_activity.run()
 
-    assert current_activity.poll.called
+    assert boto_client.poll_for_activity_task.called
     assert current_activity.on_exception.called
     assert not current_activity.execute_activity.called
-    assert not current_activity.complete.called
+    assert not boto_client.respond_activity_task_completed.called
 
     current_activity.on_exception = None
     current_activity.logger.error = MagicMock()
@@ -195,97 +201,103 @@ def test_run_capture_poll_exception(monkeypatch, poll):
     current_activity.logger.error.assert_called_with(exception, exc_info=True)
 
 
-def test_run_activity_without_id(monkeypatch):
+def test_run_activity_without_id(monkeypatch, boto_client):
     """Run an activity without an activity id.
     """
 
-    current_activity = activity_run(monkeypatch, dict())
+    current_activity = activity_run(monkeypatch, boto_client, poll=dict())
     current_activity.run()
 
-    assert current_activity.poll.called
+    assert boto_client.poll_for_activity_task.called
     assert not current_activity.execute_activity.called
-    assert not current_activity.complete.called
+    assert not boto_client.respond_activity_task_completed.called
 
 
-def test_run_activity_with_context(monkeypatch, poll):
+def test_run_activity_with_context(monkeypatch, boto_client, poll):
     """Run an activity with a context.
     """
 
     context = dict(foo='bar')
     poll.update(input=json.dumps(context))
 
-    current_activity = activity_run(monkeypatch, poll=poll)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll)
     current_activity.run()
 
-    activity_context = current_activity.execute_activity.call_args[0][0]
-    assert activity_context == context
+    activity_execution = current_activity.execute_activity.call_args[0][0]
+    assert activity_execution.context == context
 
 
-def test_run_activity_with_result(monkeypatch, poll):
+def test_run_activity_with_result(monkeypatch, boto_client, poll):
     """Run an activity with a result.
     """
 
-    resp = dict(foo='bar')
-    mock = MagicMock(return_value=resp)
-    current_activity = activity_run(monkeypatch, poll=poll, execute=mock)
+    result = dict(foo='bar')
+    mock = MagicMock(return_value=result)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll,
+        execute=mock)
     current_activity.run()
-    result = current_activity.complete.call_args_list[0][1].get('result')
-    assert result == json.dumps(resp)
+    boto_client.respond_activity_task_completed.assert_called_with(
+        result=json.dumps(result), taskToken=poll.get('taskToken'))
 
 
-def test_task_failure(monkeypatch, poll):
+def test_task_failure(monkeypatch, boto_client, poll):
     """Run an activity that has a bad task.
     """
 
     resp = dict(foo='bar')
     mock = MagicMock(return_value=resp)
-    current_activity = activity_run(monkeypatch, poll=poll, execute=mock)
-    current_activity.execute_activity.side_effect = Exception('fail')
+    reason = 'fail'
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll,
+        execute=mock)
+    current_activity.execute_activity.side_effect = Exception(reason)
     current_activity.run()
 
-    assert current_activity.fail.called
+    boto_client.respond_activity_task_failed.assert_called_with(
+        taskToken=poll.get('taskToken'),
+        reason=reason)
 
 
-def test_task_failure_on_close_activity(monkeypatch, poll):
+def test_task_failure_on_close_activity(monkeypatch, boto_client, poll):
     """Run an activity failure when the task is already closed.
     """
 
     resp = dict(foo='bar')
     mock = MagicMock(return_value=resp)
-    current_activity = activity_run(monkeypatch, poll=poll, execute=mock)
+    current_activity = activity_run(monkeypatch, boto_client, poll=poll,
+        execute=mock)
     current_activity.execute_activity.side_effect = Exception('fail')
-    current_activity.fail.side_effect = Exception('fail')
+    boto_client.respond_activity_task_failed.side_effect = Exception('fail')
     current_activity.unset_log_context = MagicMock()
     current_activity.run()
 
     assert current_activity.unset_log_context.called
 
 
-def test_execute_activity(monkeypatch):
+def test_execute_activity(monkeypatch, boto_client):
     """Test the execution of an activity.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    monkeypatch.setattr(activity.Activity, 'heartbeat', lambda self: None)
+    monkeypatch.setattr(activity.ActivityExecution, 'heartbeat',
+        lambda self: None)
 
     resp = dict(task_resp='something')
     custom_task = MagicMock(return_value=resp)
 
-    current_activity = activity.Activity()
+    current_activity = activity.Activity(boto_client)
     current_activity.runner = runner.Sync(custom_task)
 
-    val = current_activity.execute_activity(dict(foo='bar'))
+    val = current_activity.execute_activity(activity.ActivityExecution(
+        boto_client, 'activityId', 'taskToken', '{"context": "value"}'))
 
     assert custom_task.called
     assert val == resp
 
 
-def test_hydrate_activity(monkeypatch):
+def test_hydrate_activity(monkeypatch, boto_client):
     """Test the hydratation of an activity.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    current_activity = activity.Activity()
+    current_activity = activity.Activity(boto_client)
     current_activity.hydrate(dict(
         name='activity',
         domain='domain',
@@ -294,26 +306,25 @@ def test_hydrate_activity(monkeypatch):
         tasks=[lambda: dict('val')]))
 
 
-def test_create_activity(monkeypatch):
+def test_create_activity(monkeypatch, boto_client):
     """Test the creation of an activity via `create`.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    create = activity.create('domain_name', 'flow_name')
+    create = activity.create(boto_client, 'domain_name', 'flow_name')
 
     current_activity = create(name='activity_name')
     assert isinstance(current_activity, activity.Activity)
     assert current_activity.name == 'flow_name_activity_name'
     assert current_activity.task_list == 'flow_name_activity_name'
-    assert current_activity.domain == 'domain_name'
+    assert current_activity.domain is 'domain_name'
+    assert current_activity.client is boto_client
 
 
-def test_create_external_activity(monkeypatch):
+def test_create_external_activity(monkeypatch, boto_client):
     """Test the creation of an external activity via `create`.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    create = activity.create('domain_name', 'flow_name')
+    create = activity.create(boto_client, 'domain_name', 'flow_name')
 
     current_activity = create(
         name='activity_name',
@@ -335,7 +346,6 @@ def test_create_activity_worker(monkeypatch):
     """Test the creation of an activity worker.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
     from tests.fixtures.flows import example
 
     worker = activity.ActivityWorker(example)
@@ -345,14 +355,12 @@ def test_create_activity_worker(monkeypatch):
     assert not worker.worker_activities
 
 
-def test_instances_creation(monkeypatch, generators):
+def test_instances_creation(monkeypatch, boto_client, generators):
     """Test the creation of an activity instance id with the use of a local
     context.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-
-    local_activity = activity.Activity()
+    local_activity = activity.Activity(boto_client)
     external_activity = activity.ExternalActivity(timeout=60)
 
     for current_activity in [local_activity, external_activity]:
@@ -374,7 +382,7 @@ def test_instances_creation(monkeypatch, generators):
             assert not instances[0].local_context
 
 
-def test_activity_timeouts(monkeypatch, generators):
+def test_activity_timeouts(monkeypatch, boto_client, generators):
     """Test the creation of an activity timeouts.
 
     More details: the timeout of a task is 120s, the schedule to start is 1000,
@@ -390,8 +398,7 @@ def test_activity_timeouts(monkeypatch, generators):
     def local_task():
         return
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    current_activity = activity.Activity()
+    current_activity = activity.Activity(boto_client)
     current_activity.hydrate(dict(schedule_to_start=start_timeout))
     current_activity.generators = generators
     current_activity.runner = runner.Sync(
@@ -408,14 +415,13 @@ def test_activity_timeouts(monkeypatch, generators):
             schedule_to_start + instance.timeout)
 
 
-def test_external_activity_timeouts(monkeypatch, generators):
+def test_external_activity_timeouts(monkeypatch, boto_client, generators):
     """Test the creation of an external activity timeouts.
     """
 
     timeout = 120
     start_timeout = 1000
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
     current_activity = activity.ExternalActivity(timeout=timeout)
     current_activity.hydrate(dict(schedule_to_start=start_timeout))
     current_activity.generators = generators
@@ -430,44 +436,39 @@ def test_external_activity_timeouts(monkeypatch, generators):
             schedule_to_start + instance.timeout)
 
 
-def test_worker_run(monkeypatch):
+@pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+def test_worker_run(monkeypatch, boto_client):
     """Test running the worker.
     """
-
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
 
     from tests.fixtures.flows import example
 
     worker = activity.ActivityWorker(example)
     assert len(worker.activities) == 4
     for current_activity in worker.activities:
-            monkeypatch.setattr(
-                current_activity, 'run', MagicMock(return_value=False))
+        monkeypatch.setattr(
+            current_activity, 'run', MagicMock(return_value=False))
 
     worker.run()
 
     assert len(worker.activities) == 4
     for current_activity in worker.activities:
-        # this check was originally `assert current_activity.run.called`
-        # for some reason this fails on py2.7, so we explicitly check for
-        # `called == 1`.
-        assert current_activity.run.called == 1
+        assert current_activity.run.called
 
 
 def test_worker_run_with_skipped_activities(monkeypatch):
     """Test running the worker with defined activities.
     """
 
-    monkeypatch.setattr(activity.Activity, '__init__', lambda self: None)
-    monkeypatch.setattr(
-        activity.Activity, 'run', MagicMock(return_value=False))
+    monkeypatch.setattr(activity.Activity, 'run', MagicMock(return_value=False))
+
     from tests.fixtures.flows import example
 
     worker = activity.ActivityWorker(example, activities=['activity_1'])
     assert len(worker.worker_activities) == 1
     for current_activity in worker.activities:
-            monkeypatch.setattr(
-                current_activity, 'run', MagicMock(return_value=False))
+        monkeypatch.setattr(
+            current_activity, 'run', MagicMock(return_value=False))
 
     worker.run()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,24 +3,15 @@ try:
     from unittest.mock import MagicMock
 except:
     from mock import MagicMock
-import boto.swf.layer2 as swf
 
 from garcon import context
 from tests.fixtures import decider as decider_events
-
-
-def mock(monkeypatch):
-    for base in [swf.Decider, swf.WorkflowType, swf.ActivityType, swf.Domain]:
-        monkeypatch.setattr(base, '__init__', MagicMock(return_value=None))
-        if base is not swf.Decider:
-            monkeypatch.setattr(base, 'register', MagicMock())
 
 
 def test_context_creation_without_events(monkeypatch):
     """Check the basic context creation.
     """
 
-    mock(monkeypatch)
     current_context = context.ExecutionContext()
     assert not current_context.current
     assert not current_context.workflow_input
@@ -30,7 +21,6 @@ def test_context_creation_with_events(monkeypatch):
     """Test context creation with events.
     """
 
-    mock(monkeypatch)
     from tests.fixtures import decider as poll
 
     current_context = context.ExecutionContext(poll.history.get('events'))
@@ -40,7 +30,6 @@ def test_get_workflow_execution_info(monkeypatch):
     """Check that the workflow execution info are properly extracted
     """
 
-    mock(monkeypatch)
     from tests.fixtures import decider as poll
 
     current_context = context.ExecutionContext()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ try:
     from unittest.mock import MagicMock
 except:
     from mock import MagicMock
-import boto.exception as boto_exception
+from botocore import exceptions
 import datetime
 import pytest
 import json
@@ -53,23 +53,15 @@ def test_non_throttle_error():
     """Assert SWF error is evaluated as non-throttle error properly.
     """
 
-    response_status = 400
-    response_reason = 'Bad Request'
-    reponse_body = (
-        '{"__type": "com.amazon.coral.availability#ThrottlingException",'
-        '"message": "Rate exceeded"}')
-    json_body = json.loads(reponse_body)
-    exception = boto_exception.SWFResponseError(
-        response_status, response_reason, body=json_body)
+    exception = exceptions.ClientError(
+        {'Error': {'Code': 'ThrottlingException'}},
+        'operationName')
     result = utils.non_throttle_error(exception)
     assert not utils.non_throttle_error(exception)
 
-    reponse_body = (
-        '{"__type": "com.amazon.coral.availability#OtheException",'
-        '"message": "Rate exceeded"}')
-    json_body = json.loads(reponse_body)
-    exception = boto_exception.SWFResponseError(
-        response_status, response_reason, body=json_body)
+    exception = exceptions.ClientError(
+        {'Error': {'Code': 'RateExceeded'}},
+        'operationName')
     assert utils.non_throttle_error(exception)
 
 def test_throttle_backoff_handler():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Boto3 has been out for some time now and boto2 will likely be
deprecated in months / years to come. Since most AWS users are
now on boto3, migrating Garcon to Boto3.

This upgrade introduces couple breaking changes:
* `Workflow` now needs a `client` (`boto3.client('aws', region_name='us-east-1')`)
  to work. It enables workflows to run on specific AWS regions.
* `ActivityExecution` is now passed to the Runner instead of the
  `Activity`. Similar to boto2 activities, you can perform operations
  on the execution such as `complete`, `fail` and `heartbeat`.