### PR TITLE
Fix threading error leading to boto3 S3 failures

### DIFF
--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -551,6 +551,7 @@ class ActivityWorker():
         for thread in threads:
             thread.join()
 
+
 class ActivityState:
     """
     Activity State

--- a/garcon/activity.py
+++ b/garcon/activity.py
@@ -537,13 +537,19 @@ class ActivityWorker():
     def run(self):
         """Run the activities.
         """
-
+        threads = []
         for activity in self.activities:
             if (self.worker_activities and
                     activity.name not in self.worker_activities):
                 continue
-            threading.Thread(target=worker_runner, args=(activity,)).start()
+            thread = threading.Thread(
+                target=worker_runner,
+                args=(activity,))
+            thread.start()
+            threads.append(thread)
 
+        for thread in threads:
+            thread.join()
 
 class ActivityState:
     """


### PR DESCRIPTION
This PR fixes error with boto3 S3 client during file transfer

```
RuntimeError: cannot schedule new futures after interpreter shutdown
```

All created threads have to be joined with starter threads. It will fix s3transfer methods in boto3.

Boto3 issues discussed here:
* https://github.com/boto/boto3/issues/3113
* https://github.com/boto/boto3/issues/3221#issuecomment-1169369661
* https://github.com/boto/s3transfer/issues/197

This issue is actual for python >=3.9
The root Cpython issue: https://github.com/python/cpython/issues/86813